### PR TITLE
Markdown shortcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ migrations/
 venv/
 whoosh/
 __pycache__/
+.idea/

--- a/page/settings.py
+++ b/page/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = (
     'haystack',
     'reversion',
     'reversion_compare',
+    'markdown_shortcodes',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 Django==1.8.3
 django-haystack==2.4.0
 django-markdown==0.8.4
+django-markdown-shortcodes==1.3
 django-reversion==1.8.7
 django-reversion-compare==0.5.4
 Markdown==2.6.2
 python-ptrace==0.8.1
 six==1.9.0
 Unidecode==0.4.18
+wheel==0.24.0
 Whoosh==2.7.0


### PR DESCRIPTION
- Added [markdown shortcodes](https://github.com/defbyte/django-markdown-shortcodes) to the installed apps.
- Added .idea/ to gitignore

We can now create custom markdown syntax. This makes issue #7 doable.
