### PR TITLE
Fixes #7 - added shortcode for internal links

### DIFF
--- a/page/settings.py
+++ b/page/settings.py
@@ -117,16 +117,12 @@ TEMPLATE_DIRS = (
 
 # Markdown
 
-MARKDOWN_EXTENSIONS = ['extra', 'wikilinks', 'toc']
+MARKDOWN_EXTENSIONS = ['extra', 'toc']
 MARKDOWN_EXTENSION_CONFIGS = {
     'toc': {
         'separator': '-',
         'title': 'Innhold',
         'baselevel': 2,
-    },
-    'wikilinks': {
-        'base_url': '/view/',
-        'end_url': '.html',
     },
 }
 

--- a/wiki/templates/view_page.html
+++ b/wiki/templates/view_page.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load django_markdown %}
+{% load shortcodes %}
 
 {% block head %}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/default.min.css">
@@ -15,5 +16,5 @@
       [ <a href="{% url 'edit_page' page.get_url %}">Rediger</a> | <a href="{% url 'page_history' page.get_url %}">Historikk</a> ]
     </span>
   </h1>
-  {{ page.content|markdown }}
+  {{ page.content|expand_shortcodes|markdown }}
 {% endblock %}


### PR DESCRIPTION
Det viste seg at markdown-shortcodess ikke er kompatibel med python 3. Dette kan enkelt fikses ved å sette på parenteser rundt to print-er i init-fila til markdown-shortcodes. Den burde ligge i virtualenv-mappa (noe alla: venv/lib/python3.4/site-packages/markdown_shortcodes/).
